### PR TITLE
Add IWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [DEVONthink](http://www.devontechnologies.com/products/devonthink/)
 - [Exegesis](https://exegesis.io)
 - [Foam](https://www.producthunt.com/posts/foam)
+- [IWE](https://github.com/iwe-org/iwe)
 - [Logseq](https://logseq.com)
 - [nb](https://github.com/xwmx/nb)
 - [Napkin](https://www.napkin.one)


### PR DESCRIPTION
IWE is a markdown-based knowledge management tool with LSP support for Zettelkasten-style document graphs. Features include go-to-definition for links, backlinks via find references, link completion, and inclusion links for polyhierarchy.

Works with VS Code, Neovim, Zed, and Helix. Built in Rust.

GitHub: https://github.com/iwe-org/iwe