### PR TITLE
Add zk-reindex-launchd to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [roam-to-git](https://github.com/MatthieuBizien/roam-to-git). Automatic RoamResearch backup.
 - [slipbox](https://github.com/lggruspe/slipbox). A static site generator for Zettelkasten notes.
 - [vizel](https://github.com/BasilPH/vizel). See the stats and connections of your Zettelkasten.
+- [zk-reindex-launchd](https://github.com/johntrandall/zk-reindex-launchd). macOS LaunchAgent that auto-reindexes [zk](https://github.com/zk-org/zk) notebooks on a schedule. Set-and-forget — keeps queries (CLI, LSP, MCP) current after edits made outside an LSP-aware editor.
 
 ## Reference managers
 


### PR DESCRIPTION
A small macOS LaunchAgent I built that runs `zk index` on a 5-minute cycle, so [zk](https://github.com/zk-org/zk) queries (CLI, LSP, or any MCP/agent layer) stay current when notes are edited outside an LSP-aware editor — shell scripts, sync tools, or AI agents writing markdown directly. zk's own LSP already handles in-editor saves; this fills the out-of-band gap.

- [Repo](https://github.com/johntrandall/zk-reindex-launchd)
- [Homebrew tap](https://github.com/johntrandall/homebrew-tap): `brew install johntrandall/tap/zk-reindex-launchd`
- MIT licensed

Note: I opened a separate PR (#9) to fix the existing `[zk]` link on line 44, which currently points to an archived 2018 project rather than zk-org/zk. This PR is now scoped to just the Misc-section addition.