### PR TITLE
Fix zk link: point to zk-org/zk (the active project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - [The Archive](https://zettelkasten.de/the-archive/)
 - [TiddlyWiki](https://tiddlywiki.com) with extra plugins ([TiddlyBlink](https://giffmex.org/gifts/tiddlyblink.html), [TiddlyMap](http://tiddlymap.org))
 - [Zettlr](https://zettlr.com/)
-- [zk](https://github.com/AndrewCopeland/zettelkasten)
+- [zk](https://github.com/zk-org/zk). Plain-text Zettelkasten on the command line, with native LSP support and editor integrations for Neovim, Emacs, and VSCode.
 - [zknotes](https://github.com/bburdette/zknotes)
 - [Zkn³](http://zettelkasten.danielluedecke.de/en/)
 - [FSNotes](https://fsnot.es)


### PR DESCRIPTION
The existing `[zk]` link on line 44 points to [AndrewCopeland/zettelkasten](https://github.com/AndrewCopeland/zettelkasten) — an archived Python project last touched in 2018, unrelated to the active **zk Zettelkasten CLI** at [zk-org/zk](https://github.com/zk-org/zk).

The README already lists [zk-nvim](https://github.com/zk-org/zk-nvim) and [zk-vscode](https://github.com/zk-org/zk-vscode) — those are the editor integrations for the *zk-org* project, so the broken link is the odd one out.

Updated to point at the correct repo, with a one-line description matching the style of nearby entries.